### PR TITLE
Implement llama.cpp Integration Phases 0-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,15 +128,16 @@ The Ternary Fabric achieves extreme throughput by leveraging the zero-cost natur
 
 ---
 
-## 🛠️ Roadmap Status: Phase 6b Complete
+## 🛠️ Roadmap Status: Phase 6b Complete & llama.cpp Integration (Phases 0-2)
 
-We have successfully implemented and verified the multi-tile scaling architecture.
+We have successfully implemented multi-tile scaling and established the foundation for `llama.cpp` device-level acceleration.
 
 *   ✅ **Phase 1-4:** Specification, ABI, RTL, and AXI Integration.
 *   ✅ **Phase 5:** Kernel Extensions (T-CONV, T-POOL).
 *   ✅ **Phase 6a/b:** Multi-tile Scaling, Weight Broadcast, and Profiling API.
+*   ✅ **llama.cpp Integration (Phase 0-2):** Device Contract, Emulated Device (`libtfmbs_device.so`), and Memory Interposer (`libtfmbs_intercept.so`).
 *   🧪 **Experimental:** T-Conv3D, T-LSTM, and T-Attention kernels (Python reference).
-*   📅 **Next Steps:** FPGA Deployment and TNN (Ternary Neural Network) model zoo integration.
+*   📅 **Next Steps:** FPGA Deployment and llama.cpp Compute Interception (Phase 3+).
 
 ---
 

--- a/TFMBS_DEVICE_SPEC.md
+++ b/TFMBS_DEVICE_SPEC.md
@@ -1,0 +1,96 @@
+# 📄 TFMBS Device Specification (v0.1-draft)
+
+---
+
+## 1. Overview
+This document defines the normative device contract for the Ternary Fabric Memory & Bus Specification (TFMBS). It specifies the interface between a binary host (e.g., llama.cpp) and the ternary-native execution substrate.
+
+The Fabric acts as a specialized memory-compute engine that performs ternary operations (GEMV, Dot Product) directly on data residing in its own memory pool.
+
+---
+
+## 2. Memory Semantics
+
+### 2.1 Addressing
+- The Fabric operates on its own private address space (Fabric Memory).
+- All host interactions are mediated by **Ternary Frame Descriptors (TFDs)**.
+- Memory is managed in **Frames**, which are contiguous regions of ternary data.
+
+### 2.2 Packing Format (PT-5)
+- The primary packing format is **PT-5** (5 balanced trits per 8-bit byte).
+- 1 byte stores values in the range [-121, 121] when interpreted as ternary.
+- Alignment: All frame base addresses SHOULD be 64-bit aligned.
+
+### 2.3 Residency Model
+- **Resident Frames:** Weights that remain in Fabric memory across multiple inference passes.
+- **Transient Frames:** Activations or temporary buffers that are loaded, processed, and discarded.
+- **Eviction:** Managed by the host via `fabric_free` or explicit eviction commands.
+
+---
+
+## 3. Execution Interface
+
+### 3.1 Kernel: Ternary GEMV
+The primary workload for llama.cpp acceleration.
+- **Inputs:**
+  - Weight Frame (Resident)
+  - Input Vector Frame (Transient)
+- **Output:**
+  - Result Vector Frame (Host-visible)
+- **Semantics:** Performs $y = Wx$, where $W$ is ternary, $x$ is typically binary/FP (quantized to ternary by the fabric if necessary), and $y$ is binary (accumulated results).
+
+### 3.2 Async vs Sync
+- The interface supports both synchronous (blocking) and asynchronous (polling/interrupt) execution.
+- `fabric_exec_gemv` initiates the operation.
+- Completion is signalled via a status register or callback.
+
+---
+
+## 4. Host API (C ABI)
+
+The following functions define the standard interface for the Fabric Device:
+
+```c
+/**
+ * Allocate memory in the Fabric pool.
+ * Returns a handle/pointer to Fabric-resident memory.
+ */
+void* fabric_alloc(size_t size);
+
+/**
+ * Free memory in the Fabric pool.
+ */
+void fabric_free(void* ptr);
+
+/**
+ * Copy data from Host RAM to Fabric Memory.
+ * Handles automatic PT-5 packing if requested.
+ */
+int fabric_memcpy_to(void* dest_fabric, const void* src_host, size_t size, int pack_pt5);
+
+/**
+ * Copy data from Fabric Memory to Host RAM.
+ * Handles automatic PT-5 unpacking if requested.
+ */
+int fabric_memcpy_from(void* dest_host, const void* src_fabric, size_t size, int unpack_pt5);
+
+/**
+ * Execute a Ternary General Matrix-Vector multiplication.
+ */
+int fabric_exec_gemv(void* weight_ptr, void* input_ptr, void* output_ptr, int rows, int cols);
+```
+
+---
+
+## 5. Implementation Requirements
+
+- **Software Emulation Layer (SEL):** Must provide a bit-exact simulation of ternary logic for development and testing.
+- **Interconnect:** Minimum 10Gbps equivalent bandwidth for PT-5 frames.
+- **Zero-Skip:** Hardware must natively skip zero-valued trits to save power and cycles.
+
+---
+
+## 6. References
+- `specs/TERNARY_MEMORY_BUS.md`: Detailed bus and addressing specification.
+- `specs/EXECUTION_MODEL.md`: Pipeline and state transition details.
+- `specs/FRAME_MODEL.md`: Physical layout and lane organization.

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -26,6 +26,8 @@ Welcome to the **Ternary Fabric** user manual. This documentation is designed to
     Step-by-step guides for quantization, multi-tile scaling, and DMA loading.
 11. **[Appendices](docs/10_APPENDICES.md)**
     Acronyms, PT-5 details, and Phase 6b verification reports.
+12. **[llama.cpp Acceleration Roadmap](archive/llama.cpp_roadmap.md)**
+    Strategy for transparent device-level acceleration using Memory Interposition.
 
 ---
 
@@ -35,6 +37,7 @@ Check out the `examples/` directory for runnable scripts:
 *   `multi_tile_tgemm.py`: Multi-tile and broadcast demonstration.
 *   `dma_loader_demo.py`: Using the AXI-Stream DMA path.
 *   `profiling_example.py`: Extracting hardware performance counters.
+*   `tests/mock_llama.c`: Demonstrating `LD_PRELOAD` memory redirection.
 
 ---
 © 2026 Ternary Fabric Project. All rights reserved.

--- a/archive/llama.cpp_roadmap_progress.md
+++ b/archive/llama.cpp_roadmap_progress.md
@@ -1,0 +1,43 @@
+# 🧭 Roadmap Progress — Device-Level Fabric Acceleration
+
+## Status Summary (Phases 0-2 Complete)
+
+We have successfully implemented the first three phases of the roadmap, establishing a solid foundation for transparently accelerating `llama.cpp` using the Ternary Fabric.
+
+### Phase 0: Device Contract Defined ✅
+- **Deliverable:** `TFMBS_DEVICE_SPEC.md`
+- **Accomplishment:** Consolidated existing technical specs into a single normative device contract. Defined the C ABI for memory management (`fabric_alloc`, `fabric_free`), data transport (`fabric_memcpy_to/from`), and execution (`fabric_exec_gemv`).
+
+### Phase 1: Emulated Device (User-Space) ✅
+- **Deliverable:** `bin/libtfmbs_device.so`
+- **Accomplishment:** Created a C-based emulator that implements a 128MB Fabric Memory Pool. Included bit-exact PT-5 packing/unpacking logic and a mock GEMV execution engine.
+- **Verification:** Successfully passed `tests/test_device.c`.
+
+### Phase 2: Memory Interposition Layer ✅
+- **Deliverable:** `bin/libtfmbs_intercept.so`
+- **Accomplishment:** Implemented an `LD_PRELOAD` interposer that transparently redirects large memory allocations (`malloc` > 1MB, `mmap` > 1MB) and memory move operations (`memcpy`, `memset`) to the Fabric.
+- **Verification:** Demonstrated "The Illusion" using `tests/mock_llama.c`. A mock application unknowingly used Fabric-resident memory for its weights while maintaining standard CPU-based compute compatibility.
+
+### How to Verify
+To run the emulated device and interceptor tests:
+```bash
+make all
+# Run device-level unit tests
+LD_LIBRARY_PATH=./bin ./bin/test_device
+# Run transparent interposer verification
+LD_PRELOAD=./bin/libtfmbs_intercept.so LD_LIBRARY_PATH=./bin ./bin/mock_llama
+```
+
+---
+
+## 🚀 Next Steps
+
+### Phase 3: Pattern Recognition for Compute
+- Implement heuristics in `libtfmbs_intercept.so` to detect GEMV loops.
+- Log candidate regions for offload.
+
+### Phase 4: Weight Residency & Compression
+- Automatically convert intercepted weight buffers into PT-5 format upon first touch or during `memcpy`.
+
+### Phase 5: Execution Injection
+- Replace detected CPU GEMV loops with calls to `fabric_exec_gemv`.

--- a/include/tfmbs_device.h
+++ b/include/tfmbs_device.h
@@ -1,0 +1,55 @@
+#ifndef TFMBS_DEVICE_H
+#define TFMBS_DEVICE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Allocate memory in the Fabric pool.
+ * Returns a handle/pointer to Fabric-resident memory.
+ */
+void* fabric_alloc(size_t size);
+
+/**
+ * Free memory in the Fabric pool.
+ */
+void fabric_free(void* ptr);
+
+/**
+ * Copy data from Host RAM to Fabric Memory.
+ * If pack_pt5 is non-zero, it assumes src_host contains raw ternary values (-1, 0, 1)
+ * and packs them into PT-5 format in the Fabric.
+ * If pack_pt5 is zero, it performs a raw byte copy.
+ */
+int fabric_memcpy_to(void* dest_fabric, const void* src_host, size_t size, int pack_pt5);
+
+/**
+ * Copy data from Fabric Memory to Host RAM.
+ * If unpack_pt5 is non-zero, it assumes dest_fabric contains PT-5 data
+ * and unpacks it into raw ternary values (-1, 0, 1) in the Host buffer.
+ */
+int fabric_memcpy_from(void* dest_host, const void* src_fabric, size_t size, int unpack_pt5);
+
+/**
+ * Execute a Ternary General Matrix-Vector multiplication.
+ * y = W * x
+ * @param weight_ptr Fabric-resident weight matrix (PT-5 packed)
+ * @param input_ptr Fabric-resident input vector (PT-5 packed)
+ * @param output_ptr Fabric-resident output vector (binary int32_t)
+ */
+int fabric_exec_gemv(void* weight_ptr, void* input_ptr, void* output_ptr, int rows, int cols);
+
+/**
+ * Helper to check if a pointer belongs to the Fabric pool.
+ */
+int is_fabric_ptr(const void* ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TFMBS_DEVICE_H

--- a/src/libtfmbs_device.c
+++ b/src/libtfmbs_device.c
@@ -1,0 +1,162 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include "tfmbs_device.h"
+
+#define FABRIC_POOL_SIZE (128 * 1024 * 1024) // 128 MB for emulation
+
+static uint8_t* g_fabric_pool = NULL;
+static size_t g_fabric_used = 0;
+
+static void init_fabric_pool() {
+    if (!g_fabric_pool) {
+        g_fabric_pool = (uint8_t*)mmap(NULL, FABRIC_POOL_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+        if (g_fabric_pool == MAP_FAILED) {
+            perror("[TFMBS-Device] Failed to mmap Fabric pool");
+            exit(1);
+        }
+        __builtin_memset(g_fabric_pool, 0, FABRIC_POOL_SIZE);
+        g_fabric_used = 0;
+        printf("[TFMBS-Device] Fabric pool initialized at %p (%d MB)\n", g_fabric_pool, FABRIC_POOL_SIZE / (1024*1024));
+    }
+}
+
+void* fabric_alloc(size_t size) {
+    init_fabric_pool();
+
+    // Alignment to 64 bytes
+    size_t aligned_size = (size + 63) & ~63;
+
+    if (g_fabric_used + aligned_size > FABRIC_POOL_SIZE) {
+        fprintf(stderr, "[TFMBS-Device] Out of Fabric Memory! Requested %zu, used %zu/%d\n",
+                aligned_size, g_fabric_used, FABRIC_POOL_SIZE);
+        return NULL;
+    }
+
+    void* ptr = g_fabric_pool + g_fabric_used;
+    g_fabric_used += aligned_size;
+    return ptr;
+}
+
+void fabric_free(void* ptr) {
+    // Basic mock doesn't support individual frees yet
+    (void)ptr;
+}
+
+int is_fabric_ptr(const void* ptr) {
+    if (!g_fabric_pool) return 0;
+    return (uint8_t*)ptr >= g_fabric_pool && (uint8_t*)ptr < (g_fabric_pool + FABRIC_POOL_SIZE);
+}
+
+static uint8_t pack_trits_to_byte(const int8_t trits[5]) {
+    uint8_t byte_val = 0;
+    uint8_t p3 = 1;
+    for (int i = 0; i < 5; i++) {
+        uint8_t unsigned_trit = trits[i] + 1; // map -1,0,1 to 0,1,2
+        byte_val += (unsigned_trit * p3);
+        p3 *= 3;
+    }
+    return byte_val;
+}
+
+static void unpack_byte_to_trits(uint8_t byte_val, int8_t trits[5]) {
+    for (int i = 0; i < 5; i++) {
+        uint8_t unsigned_trit = byte_val % 3;
+        trits[i] = (int8_t)unsigned_trit - 1;
+        byte_val /= 3;
+    }
+}
+
+int fabric_memcpy_to(void* dest_fabric, const void* src_host, size_t size, int pack_pt5) {
+    if (!is_fabric_ptr(dest_fabric)) return -1;
+
+    if (pack_pt5) {
+        size_t num_trits = size;
+        size_t num_bytes = (num_trits + 4) / 5;
+        const int8_t* src = (const int8_t*)src_host;
+        uint8_t* dest = (uint8_t*)dest_fabric;
+
+        for (size_t i = 0; i < num_bytes; i++) {
+            int8_t trits[5] = {0, 0, 0, 0, 0};
+            for (int j = 0; j < 5; j++) {
+                if (i * 5 + j < num_trits) trits[j] = src[i * 5 + j];
+            }
+            dest[i] = pack_trits_to_byte(trits);
+        }
+    } else {
+        __builtin_memcpy(dest_fabric, src_host, size);
+    }
+    return 0;
+}
+
+int fabric_memcpy_from(void* dest_host, const void* src_fabric, size_t size, int unpack_pt5) {
+    if (!is_fabric_ptr(src_fabric)) return -1;
+
+    if (unpack_pt5) {
+        size_t num_trits = size;
+        size_t num_bytes = (num_trits + 4) / 5;
+        const uint8_t* src = (const uint8_t*)src_fabric;
+        int8_t* dest = (int8_t*)dest_host;
+
+        for (size_t i = 0; i < num_bytes; i++) {
+            int8_t trits[5];
+            unpack_byte_to_trits(src[i], trits);
+            for (int j = 0; j < 5; j++) {
+                if (i * 5 + j < num_trits) dest[i * 5 + j] = trits[j];
+            }
+        }
+    } else {
+        __builtin_memcpy(dest_host, src_fabric, size);
+    }
+    return 0;
+}
+
+int fabric_exec_gemv(void* weight_ptr, void* input_ptr, void* output_ptr, int rows, int cols) {
+    if (!is_fabric_ptr(weight_ptr) || !is_fabric_ptr(input_ptr) || !is_fabric_ptr(output_ptr)) {
+        fprintf(stderr, "[TFMBS-Device] GEMV Error: Non-fabric pointer provided\n");
+        return -1;
+    }
+
+    int8_t* w_trits = (int8_t*)malloc(rows * cols);
+    int8_t* i_trits = (int8_t*)malloc(cols);
+    int32_t* results = (int32_t*)output_ptr;
+
+    if (!w_trits || !i_trits) {
+        free(w_trits); free(i_trits);
+        return -1;
+    }
+
+    // Unpack weights
+    uint8_t* w_packed = (uint8_t*)weight_ptr;
+    for (int i = 0; i < (rows * cols + 4) / 5; i++) {
+        int8_t trits[5];
+        unpack_byte_to_trits(w_packed[i], trits);
+        for (int j = 0; j < 5; j++) {
+            if (i * 5 + j < rows * cols) w_trits[i * 5 + j] = trits[j];
+        }
+    }
+
+    // Unpack inputs
+    uint8_t* i_packed = (uint8_t*)input_ptr;
+    for (int i = 0; i < (cols + 4) / 5; i++) {
+        int8_t trits[5];
+        unpack_byte_to_trits(i_packed[i], trits);
+        for (int j = 0; j < 5; j++) {
+            if (i * 5 + j < cols) i_trits[i * 5 + j] = trits[j];
+        }
+    }
+
+    // GEMV
+    for (int r = 0; r < rows; r++) {
+        int32_t acc = 0;
+        for (int c = 0; c < cols; c++) {
+            acc += (int32_t)w_trits[r * cols + c] * (int32_t)i_trits[c];
+        }
+        results[r] = acc;
+    }
+
+    free(w_trits);
+    free(i_trits);
+    return 0;
+}

--- a/src/libtfmbs_intercept.c
+++ b/src/libtfmbs_intercept.c
@@ -1,0 +1,139 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <pthread.h>
+#include "tfmbs_device.h"
+
+static void* (*real_malloc)(size_t) = NULL;
+static void (*real_free)(void*) = NULL;
+static void* (*real_realloc)(void*, size_t) = NULL;
+static void* (*real_memcpy)(void*, const void*, size_t) = NULL;
+static void* (*real_memset)(void*, int, size_t) = NULL;
+static void* (*real_mmap)(void*, size_t, int, int, int, off_t) = NULL;
+
+static __thread int in_interposer = 0;
+static int initializing = 0;
+static char tmp_alloc_buf[16384];
+static size_t tmp_alloc_used = 0;
+
+#define FABRIC_THRESHOLD (1024 * 1024)
+
+static void init_intercept() {
+    if (real_malloc || initializing) return;
+    initializing = 1;
+
+    real_malloc = dlsym(RTLD_NEXT, "malloc");
+    real_free = dlsym(RTLD_NEXT, "free");
+    real_realloc = dlsym(RTLD_NEXT, "realloc");
+    real_memcpy = dlsym(RTLD_NEXT, "memcpy");
+    real_memset = dlsym(RTLD_NEXT, "memset");
+    real_mmap = dlsym(RTLD_NEXT, "mmap");
+
+    initializing = 0;
+}
+
+void* malloc(size_t size) {
+    if (!real_malloc) {
+        init_intercept();
+        if (!real_malloc) {
+            // dlsym is calling malloc during initialization
+            if (tmp_alloc_used + size < sizeof(tmp_alloc_buf)) {
+                void* ptr = tmp_alloc_buf + tmp_alloc_used;
+                tmp_alloc_used += size;
+                return ptr;
+            }
+            return NULL;
+        }
+    }
+
+    if (in_interposer) return real_malloc(size);
+
+    if (size >= FABRIC_THRESHOLD) {
+        in_interposer = 1;
+        void* ptr = fabric_alloc(size);
+        in_interposer = 0;
+        if (ptr) {
+            fprintf(stderr, "[TFMBS-Intercept] Redirected malloc(%zu) -> Fabric: %p\n", size, ptr);
+            return ptr;
+        }
+    }
+    return real_malloc(size);
+}
+
+void free(void* ptr) {
+    if (!ptr) return;
+    if (ptr >= (void*)tmp_alloc_buf && ptr < (void*)(tmp_alloc_buf + sizeof(tmp_alloc_buf))) {
+        return;
+    }
+
+    if (!real_free) init_intercept();
+
+    if (is_fabric_ptr(ptr)) {
+        fabric_free(ptr);
+        return;
+    }
+    if (real_free) real_free(ptr);
+}
+
+void* realloc(void* ptr, size_t size) {
+    if (!real_realloc) init_intercept();
+    if (in_interposer || !real_realloc) return real_realloc ? real_realloc(ptr, size) : NULL;
+
+    if (is_fabric_ptr(ptr)) {
+        fprintf(stderr, "[TFMBS-Intercept] WARNING: realloc on Fabric pointer %p\n", ptr);
+        void* new_ptr = malloc(size);
+        return new_ptr;
+    }
+    return real_realloc(ptr, size);
+}
+
+void* memcpy(void* dest, const void* src, size_t n) {
+    if (!real_memcpy) init_intercept();
+    if (in_interposer || !real_memcpy) return real_memcpy ? real_memcpy(dest, src, n) : __builtin_memcpy(dest, src, n);
+
+    if (is_fabric_ptr(dest)) {
+        in_interposer = 1;
+        fabric_memcpy_to(dest, src, n, 0);
+        in_interposer = 0;
+        return dest;
+    }
+    if (is_fabric_ptr(src)) {
+        in_interposer = 1;
+        fabric_memcpy_from(dest, src, n, 0);
+        in_interposer = 0;
+        return dest;
+    }
+    return real_memcpy(dest, src, n);
+}
+
+void* memset(void* s, int c, size_t n) {
+    if (!real_memset) init_intercept();
+    if (in_interposer || !real_memset) return real_memset ? real_memset(s, c, n) : __builtin_memset(s, c, n);
+
+    if (is_fabric_ptr(s)) {
+        in_interposer = 1;
+        real_memset(s, c, n);
+        in_interposer = 0;
+        return s;
+    }
+    return real_memset(s, c, n);
+}
+
+void* mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
+    if (!real_mmap) init_intercept();
+    if (in_interposer || !real_mmap) return real_mmap ? real_mmap(addr, length, prot, flags, fd, offset) : MAP_FAILED;
+
+    if (length >= FABRIC_THRESHOLD && (flags & MAP_ANONYMOUS)) {
+        in_interposer = 1;
+        void* ptr = fabric_alloc(length);
+        in_interposer = 0;
+        if (ptr) {
+            fprintf(stderr, "[TFMBS-Intercept] Redirected mmap(%zu) -> Fabric: %p\n", length, ptr);
+            return ptr;
+        }
+    }
+    return real_mmap(addr, length, prot, flags, fd, offset);
+}

--- a/tests/mock_llama.c
+++ b/tests/mock_llama.c
@@ -1,0 +1,65 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+int main() {
+    printf("--- Mock llama.cpp Starting ---\n");
+
+    // 1. Allocate weights (2MB > 1MB threshold)
+    size_t weight_size = 2 * 1024 * 1024;
+    printf("Allocating weights (%zu bytes)...\n", weight_size);
+    char* weights = (char*)malloc(weight_size);
+    if (!weights) {
+        printf("Failed to allocate weights\n");
+        return 1;
+    }
+
+    // 2. Initialize weights
+    printf("Initializing weights...\n");
+    memset(weights, 1, weight_size);
+
+    // 3. Allocate activation (1KB < 1MB threshold)
+    size_t act_size = 1024;
+    printf("Allocating activations (%zu bytes)...\n", act_size);
+    char* act = (char*)malloc(act_size);
+    if (!act) {
+        printf("Failed to allocate activations\n");
+        return 1;
+    }
+    memset(act, 2, act_size);
+
+    // 4. Perform "compute"
+    printf("Performing compute loop...\n");
+    long sum = 0;
+    for (size_t i = 0; i < 1000; i++) {
+        sum += weights[i] * act[i];
+    }
+
+    printf("Result: %ld (Expected: 2000)\n", sum);
+
+    // 5. Verify data integrity in Fabric
+    // If weights were redirected, they should still be readable.
+    if (weights[500] != 1) {
+        printf("DATA CORRUPTION in weights!\n");
+    } else {
+        printf("Data integrity verified.\n");
+    }
+
+    free(weights);
+    free(act);
+
+    // 6. Test mmap redirection
+    printf("Testing mmap redirection...\n");
+    size_t mmap_size = 4 * 1024 * 1024;
+    void* mmap_ptr = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (mmap_ptr == MAP_FAILED) {
+        printf("mmap failed\n");
+    } else {
+        printf("mmap succeeded at %p\n", mmap_ptr);
+        munmap(mmap_ptr, mmap_size);
+    }
+
+    printf("--- Mock llama.cpp Finished ---\n");
+    return 0;
+}

--- a/tests/test_device.c
+++ b/tests/test_device.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+#include "tfmbs_device.h"
+
+int main() {
+    printf("Testing TFMBS Device Emulator...\n");
+
+    // 1. Test Allocation
+    int8_t* weight_host = (int8_t*)malloc(15);
+    for(int i=0; i<15; i++) weight_host[i] = (i % 3) - 1;
+
+    void* weight_fabric = fabric_alloc(3); // 15 trits = 3 bytes PT-5
+    assert(weight_fabric != NULL);
+    assert(is_fabric_ptr(weight_fabric));
+
+    // 2. Test Memcpy To (with packing)
+    fabric_memcpy_to(weight_fabric, weight_host, 15, 1);
+
+    // 3. Test Memcpy From (with unpacking)
+    int8_t* weight_unpacked = (int8_t*)malloc(15);
+    fabric_memcpy_from(weight_unpacked, weight_fabric, 15, 1);
+
+    for(int i=0; i<15; i++) {
+        assert(weight_unpacked[i] == weight_host[i]);
+    }
+    printf("Memcpy PT-5 Packing/Unpacking: PASSED\n");
+
+    // 4. Test GEMV (Mock)
+    // 1x15 * 15x1
+    int8_t* input_host = (int8_t*)malloc(15);
+    for(int i=0; i<15; i++) input_host[i] = 1;
+
+    void* input_fabric = fabric_alloc(3);
+    fabric_memcpy_to(input_fabric, input_host, 15, 1);
+
+    void* output_fabric = fabric_alloc(4); // 1 int32_t
+
+    fabric_exec_gemv(weight_fabric, input_fabric, output_fabric, 1, 15);
+
+    int32_t result;
+    fabric_memcpy_from(&result, output_fabric, sizeof(int32_t), 0);
+
+    int32_t expected = 0;
+    for(int i=0; i<15; i++) expected += weight_host[i] * input_host[i];
+
+    printf("GEMV Result: %d (Expected: %d)\n", result, expected);
+    assert(result == expected);
+    printf("GEMV Mock Execution: PASSED\n");
+
+    free(weight_host);
+    free(weight_unpacked);
+    free(input_host);
+
+    printf("All Device Emulator Tests PASSED!\n");
+    return 0;
+}


### PR DESCRIPTION
This PR implements the first three phases (0, 1, and 2) of the Ternary Fabric acceleration roadmap for `llama.cpp`. 

Key accomplishments:
1.  **Phase 0 (Consolidation):** A new `TFMBS_DEVICE_SPEC.md` was created to define the normative device contract, providing a clear C ABI for future integration.
2.  **Phase 1 (Emulated Device):** `libtfmbs_device.so` was developed to provide a user-space emulator of the Fabric. It includes a private 128MB memory pool, PT-5 packing/unpacking, and a mock GEMV execution engine.
3.  **Phase 2 (Memory Interposition):** `libtfmbs_intercept.so` allows transparent acceleration by using `LD_PRELOAD` to intercept `malloc`, `mmap`, and `memcpy` calls. Large allocations (>1MB) are automatically redirected to the Fabric pool.

Safety and Robustness:
- Solved infinite recursion issues in the interposer by implementing thread-local guards and an initialization state machine.
- Ensured that `libtfmbs_device.so` uses `mmap` and `__builtin` functions to avoid triggering the interposer's logic recursively.

Testing:
- `tests/test_device.c` verifies the core emulator logic.
- `tests/mock_llama.c` demonstrates the "Memory Illusion" where a host application unknowingly uses Fabric-resident memory for its weights.

Documentation:
- Updated `README.md` and `USER_MANUAL.md` to highlight the new integration capabilities.
- Detailed the accomplishments and verification steps in `archive/llama.cpp_roadmap_progress.md`.

---
*PR created automatically by Jules for task [12785556205512450207](https://jules.google.com/task/12785556205512450207) started by @t81dev*