### PR TITLE
Enable Phase 21 Multi-Fabric verification test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ OBJ_DIR = obj_dir
 VERILATOR_FLAGS = --cc $(HW_DIR)/ternary_fabric_top.v -I$(HW_DIR) --Mdir $(OBJ_DIR) -Wno-fatal
 
 # Targets
-ALL_C_BINS = $(BIN_DIR)/mediator_mock $(BIN_DIR)/pt5_example $(BIN_DIR)/reference_tfmbs $(BIN_DIR)/test_device $(BIN_DIR)/mock_llama $(BIN_DIR)/test_dynamic_detection $(BIN_DIR)/test_phase10 $(BIN_DIR)/test_multi_tile $(BIN_DIR)/test_eviction $(BIN_DIR)/sparse_stress $(BIN_DIR)/test_convergence $(BIN_DIR)/test_adaptive $(BIN_DIR)/test_multi_node_fault
+ALL_C_BINS = $(BIN_DIR)/mediator_mock $(BIN_DIR)/pt5_example $(BIN_DIR)/reference_tfmbs $(BIN_DIR)/test_device $(BIN_DIR)/mock_llama $(BIN_DIR)/test_dynamic_detection $(BIN_DIR)/test_phase10 $(BIN_DIR)/test_multi_tile $(BIN_DIR)/test_eviction $(BIN_DIR)/sparse_stress $(BIN_DIR)/test_convergence $(BIN_DIR)/test_adaptive $(BIN_DIR)/test_multi_node_fault $(BIN_DIR)/test_phase21
 ALL_LIBS = $(BIN_DIR)/libtfmbs_device$(SHLIB_EXT) $(BIN_DIR)/libtfmbs_intercept$(SHLIB_EXT)
 ALL_HW_SIM = $(BIN_DIR)/fabric_tb.vvp
 
@@ -99,6 +99,9 @@ $(BIN_DIR)/test_adaptive: tests/test_adaptive.c $(BIN_DIR)/libtfmbs_device$(SHLI
 
 $(BIN_DIR)/test_multi_node_fault: tests/test_multi_node_fault.c $(BIN_DIR)/libtfmbs_device$(SHLIB_EXT)
 	$(CC) $(CFLAGS) -Isrc -o $@ $< -L$(BIN_DIR) -ltfmbs_device
+
+$(BIN_DIR)/test_phase21: tests/test_phase21_multi_fabric.c $(BIN_DIR)/libtfmbs_device$(SHLIB_EXT)
+	$(CC) $(CFLAGS) -o $@ $< -L$(BIN_DIR) -ltfmbs_device
 
 run_mock_llama: $(BIN_DIR)/mock_llama $(ALL_LIBS)
 	export FABRIC_SHORT_CIRCUIT=1; \


### PR DESCRIPTION
This PR enables the Phase 21 Multi-Fabric verification test in the Makefile, which was previously missing from the build targets. It verifies that the existing test `tests/test_phase21_multi_fabric.c` compiles and runs successfully. The test validates multi-fabric orchestration and economic metrics reporting.

---
*PR created automatically by Jules for task [16983154404623583794](https://jules.google.com/task/16983154404623583794) started by @t81dev*